### PR TITLE
[codex] Separate setup scripts from user bin helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,16 @@ SKIP_APP_STORE=1 ./setup-a-new-machine.sh
 6. Run:
 
 ```bash
-./bin/setup-github-auth
+./script/setup-github-auth
 ```
 
 That helper uses `gh` to authenticate GitHub in the browser, set GitHub's preferred git protocol to SSH, add an `open` alias for `repo view --web`, prompt to create or upload an SSH key when needed, test `ssh -T git@github.com`, and switch this repo's `origin` remote from HTTPS to SSH.
 
-Cloning over HTTPS keeps SSH setup out of the critical path for a fresh machine. If the repo is private, use whatever HTTPS auth flow gets the first clone onto disk, then switch the machine to SSH with `./bin/setup-github-auth`.
+Cloning over HTTPS keeps SSH setup out of the critical path for a fresh machine. If the repo is private, use whatever HTTPS auth flow gets the first clone onto disk, then switch the machine to SSH with `./script/setup-github-auth`.
 
 The package source of truth is `Brewfile` for the default bootstrap and `Brewfile.optional` for opt-in extras. `setup-a-new-machine.sh` is the human-friendly entrypoint, and `brew.sh` is the package-only helper that runs `brew bundle`.
 
+The shell toolchain that this repo expects is also managed during bootstrap. `./setup-a-new-machine.sh` installs or updates `oh-my-zsh`, `zsh-autosuggestions`, and `zsh-fzf-history-search` through `./script/setup-shell`, so the default shell path is explicit instead of manual.
 This bootstrap assumes macOS or Xcode Command Line Tools already provide:
 
 - `bash`
@@ -53,18 +54,23 @@ Those are intentionally not installed from Homebrew.
 
 ## Which Script Does What
 
-`./setup-a-new-machine.sh` is the software bootstrap step for a new Mac. It runs `./brew.sh`, which runs `brew bundle` against `Brewfile` to install the default CLI tools, casks, and optional Mac App Store apps. That includes the `claude-code` cask for Claude Code. After that, it uses Homebrew `nvm` to install the current Node LTS release and installs the Codex CLI globally with npm. Pass `--optional-tools` or set `INSTALL_OPTIONAL_TOOLS=1` to also install the extras from `Brewfile.optional`. It does not symlink repo files into `$HOME`.
+`./setup-a-new-machine.sh` is the software bootstrap step for a new Mac. It runs `./brew.sh`, which runs `brew bundle` against `Brewfile` to install the default CLI tools, casks, and optional Mac App Store apps. That includes the `claude-code` cask for Claude Code. After that, it runs `./script/setup-shell` to install or update the repo-managed Zsh stack, then uses Homebrew `nvm` to install the current Node LTS release and installs the Codex CLI globally with npm. Pass `--optional-tools` or set `INSTALL_OPTIONAL_TOOLS=1` to also install the extras from `Brewfile.optional`. It does not symlink repo files into `$HOME`.
 
-`./bin/setup-github-auth` is the GitHub auth step after bootstrap. It uses the installed GitHub CLI to sign in with `--git-protocol ssh`, configures the `open` alias for `repo view --web`, lets GitHub CLI create or upload an SSH key if needed, tests the SSH connection to GitHub, and switches this repo's `origin` remote from HTTPS to SSH.
+`./script/setup-shell` is the shell bootstrap helper. It installs or updates `oh-my-zsh`, `zsh-autosuggestions`, and `zsh-fzf-history-search` in the standard Oh My Zsh locations without overwriting the repo-managed `~/.zshrc`. Re-run it whenever you want to refresh those shell dependencies outside the full machine bootstrap.
 
-`./move-in.sh` is the dotfile linking step. It creates symlinks for the small set of home-directory config files this repo intentionally manages, and it symlinks every file in `bin/` into `~/bin`. It does not install Homebrew packages, casks, or App Store apps.
+`./script/setup-github-auth` is the GitHub auth step after bootstrap. It uses the installed GitHub CLI to sign in with `--git-protocol ssh`, configures the `open` alias for `repo view --web`, lets GitHub CLI create or upload an SSH key if needed, tests the SSH connection to GitHub, and switches this repo's `origin` remote from HTTPS to SSH.
+
+`./script/setup-dock` is the repo-only Dock restore helper. It uses `dockutil` to recreate the Dock from `dock/layout.sh` when you want this repo's saved Dock layout on a machine.
+
+`./move-in.sh` is the dotfile linking step. It creates symlinks for the small set of home-directory config files this repo intentionally manages, and it symlinks only the intentionally user-facing helpers from `bin/` into `~/bin`. It does not install Homebrew packages, casks, or App Store apps.
 
 If you are setting up a fresh machine, the intended order is:
 
 1. Clone the repo over HTTPS so SSH setup does not block bootstrap.
 2. Run `./setup-a-new-machine.sh` to install software, including `gh`.
-3. Run `./bin/setup-github-auth` to authenticate GitHub and switch this repo to SSH.
-4. Review `./move-in.sh`, then run it if you want the managed dotfiles linked into `$HOME` and the repo's `bin/*` scripts symlinked into `~/bin`.
+3. Run `./script/setup-github-auth` to authenticate GitHub and switch this repo to SSH.
+4. If you installed optional tools and want this repo's Dock layout, run `./script/setup-dock`.
+5. Review `./move-in.sh`, then run it if you want the managed dotfiles linked into `$HOME` and the curated `bin/*` helpers symlinked into `~/bin`.
 
 ## What Gets Installed
 
@@ -133,13 +139,16 @@ Managed App Store installs currently include:
 Shell setup:
 
 ```bash
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+./script/setup-shell
 ```
 
-Install whatever Oh My Zsh plugins you want, for example:
+That helper is already called by `./setup-a-new-machine.sh`. It manages the shell stack this repo expects:
 
+- `oh-my-zsh`
 - `zsh-autosuggestions`
 - `zsh-fzf-history-search`
+
+`.zshrc` stays safe before and after those tools are installed because it only sources Oh My Zsh and plugin directories when they exist.
 
 This repo expects `nvm` to use `~/.nvm`.
 
@@ -172,7 +181,7 @@ Anthropic's quickstart also supports a native install script for Claude Code, bu
 GitHub setup:
 
 ```bash
-./bin/setup-github-auth
+./script/setup-github-auth
 ```
 
 That helper opens the GitHub CLI browser flow, sets GitHub's git protocol to SSH, configures the `open` alias for `repo view --web`, prompts to create or upload an SSH key if needed, tests `ssh -T git@github.com`, and updates this repo's `origin` remote to SSH.
@@ -189,10 +198,10 @@ If you installed optional tools, the Dock helpers can save and restore the repo'
 
 ```bash
 ./bin/capture-dock
-./bin/setup-dock
+./script/setup-dock
 ```
 
-`./bin/capture-dock` snapshots your current Dock into `dock/layout.sh`. `./bin/setup-dock` clears the Dock and recreates it from that saved layout, including right-side folder stacks such as `Downloads`.
+`./bin/capture-dock` snapshots your current Dock into `dock/layout.sh`. `./script/setup-dock` clears the Dock and recreates it from that saved layout, including right-side folder stacks such as `Downloads`.
 
 Shell quality-of-life notes:
 
@@ -212,25 +221,39 @@ Run `./move-in.sh` to link the dotfiles this repo intentionally manages in `$HOM
 - `.gitconfig`
 - `.zshrc`
 
-It also symlinks every file in this repo's `bin/` directory into `~/bin`.
+This repo intentionally splits helpers into two places:
 
-It does not link repo documentation, bootstrap scripts, or `Brewfile*` by default.
+- `bin/` for user-facing commands that should be available in `~/bin`
+- `script/` for repo-only setup/bootstrap helpers that should be run from this checkout
+
+`./move-in.sh` symlinks only the curated `bin/` commands into `~/bin`.
+
+It does not link repo documentation, `script/` helpers, or `Brewfile*` by default.
 
 That means these helper scripts are available on your `PATH` as symlinks from `~/bin`:
 
 - `add-ruby`
 - `capture-dock`
 - `pull-request.sh`
-- `setup-ai-coding-tools`
-- `setup-github-auth`
-- `setup-dock`
 - `symlinkToDotfilesRepo.sh`
 
-`bin/symlinkToDotfilesRepo.sh` is useful for moving files into the dotfiles repo and replacing them with symlinks.
-`bin/setup-ai-coding-tools` installs the current Node LTS release through Homebrew `nvm`, then installs Codex globally with npm.
+Repo-only setup helpers now live in `script/`:
+
+- `setup-ai-coding-tools`
+- `setup-dock`
+- `setup-github-auth`
+- `setup-shell`
+
+`bin/add-ruby` installs a Ruby version with `ruby-install` and updates `~/.extras` so `chruby` selects it automatically.
 `bin/capture-dock` snapshots the current Dock into `dock/layout.sh`.
-`bin/setup-dock` uses `dockutil` to recreate the Dock from `dock/layout.sh`.
-`bin/setup-github-auth` authenticates GitHub with `gh`, sets SSH as the preferred git protocol, configures the `open` alias for `repo view --web`, tests the SSH connection, and switches this repo's `origin` remote to SSH.
+`bin/pull-request.sh` opens the GitHub compare view for the current branch.
+`bin/symlinkToDotfilesRepo.sh` is useful for moving files into the dotfiles repo and replacing them with symlinks.
+`script/setup-ai-coding-tools` installs the current Node LTS release through Homebrew `nvm`, then installs Codex globally with npm.
+`script/setup-dock` uses `dockutil` to recreate the Dock from `dock/layout.sh`.
+`script/setup-github-auth` authenticates GitHub with `gh`, sets SSH as the preferred git protocol, configures the `open` alias for `repo view --web`, tests the SSH connection, and switches this repo's `origin` remote to SSH.
+`script/setup-shell` installs or updates the Oh My Zsh framework and the specific plugins this repo enables in `.zshrc`.
+
+Compatibility shims remain at `bin/setup-ai-coding-tools`, `bin/setup-dock`, `bin/setup-github-auth`, and `bin/setup-shell` so existing `~/bin` symlinks keep working, but `move-in.sh` no longer installs those shims on new machines.
 
 ## Postgres
 

--- a/bin/setup-ai-coding-tools
+++ b/bin/setup-ai-coding-tools
@@ -1,36 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if ! command -v brew >/dev/null 2>&1; then
-  echo "Homebrew is required. Run ./setup-a-new-machine.sh after installing brew."
+resolve_script_path() {
+  local source_path="$1"
+
+  while [[ -L "$source_path" ]]; do
+    local source_dir
+    source_dir="$(cd -P "$(dirname "$source_path")" && pwd)"
+    source_path="$(readlink "$source_path")"
+    if [[ "$source_path" != /* ]]; then
+      source_path="$source_dir/$source_path"
+    fi
+  done
+
+  printf '%s\n' "$source_path"
+}
+
+SCRIPT_PATH="$(resolve_script_path "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+DOTFILES_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TARGET_SCRIPT="$DOTFILES_DIR/script/setup-ai-coding-tools"
+
+if [[ ! -x "$TARGET_SCRIPT" ]]; then
+  echo "Expected setup helper at $TARGET_SCRIPT"
   exit 1
 fi
 
-HOMEBREW_PREFIX="$(brew --prefix)"
-NVM_SH="$HOMEBREW_PREFIX/opt/nvm/nvm.sh"
-
-if [[ ! -s "$NVM_SH" ]]; then
-  echo "nvm is required. Run ./brew.sh first to install it from the Brewfile."
-  exit 1
-fi
-
-export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
-mkdir -p "$NVM_DIR"
-
-# `nvm.sh` is not consistently `set -u` safe across releases, so disable
-# nounset while sourcing it and running nvm subcommands.
-set +u
-# shellcheck disable=SC1090
-. "$NVM_SH"
-
-nvm install --lts
-nvm alias default "lts/*"
-nvm use --lts >/dev/null
-set -u
-
-npm install -g @openai/codex
-
-echo "Installed Node $(node --version) and npm $(npm --version)."
-echo "Installed Codex globally with npm."
-echo "Claude Code is installed from the Brewfile through Homebrew Cask."
-echo "Next steps: run 'codex login' and start 'claude' once to finish authentication."
+exec "$TARGET_SCRIPT" "$@"

--- a/bin/setup-dock
+++ b/bin/setup-dock
@@ -1,46 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if ! command -v dockutil >/dev/null 2>&1; then
-  echo "dockutil is required. Install optional tools with './brew.sh install --optional-tools' first."
-  exit 1
-fi
+resolve_script_path() {
+  local source_path="$1"
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  while [[ -L "$source_path" ]]; do
+    local source_dir
+    source_dir="$(cd -P "$(dirname "$source_path")" && pwd)"
+    source_path="$(readlink "$source_path")"
+    if [[ "$source_path" != /* ]]; then
+      source_path="$source_dir/$source_path"
+    fi
+  done
+
+  printf '%s\n' "$source_path"
+}
+
+SCRIPT_PATH="$(resolve_script_path "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
 DOTFILES_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-LAYOUT_FILE="${1:-$DOTFILES_DIR/dock/layout.sh}"
+TARGET_SCRIPT="$DOTFILES_DIR/script/setup-dock"
 
-if [[ ! -f "$LAYOUT_FILE" ]]; then
-  echo "Dock layout not found at $LAYOUT_FILE"
-  echo "Run './bin/capture-dock' to save the current Dock into the repo first."
+if [[ ! -x "$TARGET_SCRIPT" ]]; then
+  echo "Expected setup helper at $TARGET_SCRIPT"
   exit 1
 fi
 
-# shellcheck disable=SC1090
-source "$LAYOUT_FILE"
-
-echo "Resetting Dock from $LAYOUT_FILE..."
-dockutil --no-restart --remove all
-
-for app in "${DOCK_APPS[@]}"; do
-  if [[ -e "$app" ]]; then
-    dockutil --no-restart --add "$app"
-  else
-    echo "Skipping missing Dock app: $app"
-  fi
-done
-
-for item in "${DOCK_OTHERS[@]:-}"; do
-  [[ -n "$item" ]] || continue
-  IFS='|' read -r path view display sort <<<"$item"
-
-  if [[ ! -e "$path" ]]; then
-    echo "Skipping missing Dock item: $path"
-    continue
-  fi
-
-  dockutil --no-restart --add "$path" --section others --view "$view" --display "$display" --sort "$sort"
-done
-
-killall Dock >/dev/null 2>&1 || true
-echo "Dock updated."
+exec "$TARGET_SCRIPT" "$@"

--- a/bin/setup-shell
+++ b/bin/setup-shell
@@ -19,7 +19,7 @@ resolve_script_path() {
 SCRIPT_PATH="$(resolve_script_path "${BASH_SOURCE[0]}")"
 SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
 DOTFILES_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-TARGET_SCRIPT="$DOTFILES_DIR/script/setup-github-auth"
+TARGET_SCRIPT="$DOTFILES_DIR/script/setup-shell"
 
 if [[ ! -x "$TARGET_SCRIPT" ]]; then
   echo "Expected setup helper at $TARGET_SCRIPT"

--- a/move-in.sh
+++ b/move-in.sh
@@ -14,6 +14,14 @@ MANAGED_HOME_FILES=(
   ".zshrc"
 )
 
+# Only these day-to-day helpers belong on PATH via ~/bin.
+MANAGED_BIN_FILES=(
+  "bin/add-ruby"
+  "bin/capture-dock"
+  "bin/pull-request.sh"
+  "bin/symlinkToDotfilesRepo.sh"
+)
+
 # Ensure the dotfiles directory exists
 if [[ ! -d "$DOTFILES_DIR" ]]; then
   echo "Error: Dotfiles directory not found at $DOTFILES_DIR"
@@ -72,13 +80,8 @@ for RELATIVE_PATH in "${MANAGED_HOME_FILES[@]}"; do
   link_managed_path "$RELATIVE_PATH"
 done
 
-if [[ -d "$DOTFILES_DIR/bin" ]]; then
-  shopt -s nullglob
-  for FILE in "$DOTFILES_DIR"/bin/*; do
-    [[ -f "$FILE" ]] || continue
-    link_managed_path "${FILE#"$DOTFILES_DIR"/}"
-  done
-  shopt -u nullglob
-fi
+for RELATIVE_PATH in "${MANAGED_BIN_FILES[@]}"; do
+  link_managed_path "$RELATIVE_PATH"
+done
 
 echo "Symlink restoration complete!"

--- a/script/setup-ai-coding-tools
+++ b/script/setup-ai-coding-tools
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v brew >/dev/null 2>&1; then
+  echo "Homebrew is required. Run ./setup-a-new-machine.sh after installing brew."
+  exit 1
+fi
+
+HOMEBREW_PREFIX="$(brew --prefix)"
+NVM_SH="$HOMEBREW_PREFIX/opt/nvm/nvm.sh"
+
+if [[ ! -s "$NVM_SH" ]]; then
+  echo "nvm is required. Run ./brew.sh first to install it from the Brewfile."
+  exit 1
+fi
+
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+mkdir -p "$NVM_DIR"
+
+# `nvm.sh` is not consistently `set -u` safe across releases, so disable
+# nounset while sourcing it and running nvm subcommands.
+set +u
+# shellcheck disable=SC1090
+. "$NVM_SH"
+
+nvm install --lts
+nvm alias default "lts/*"
+nvm use --lts >/dev/null
+set -u
+
+npm install -g @openai/codex
+
+echo "Installed Node $(node --version) and npm $(npm --version)."
+echo "Installed Codex globally with npm."
+echo "Claude Code is installed from the Brewfile through Homebrew Cask."
+echo "Next steps: run 'codex login' and start 'claude' once to finish authentication."

--- a/script/setup-dock
+++ b/script/setup-dock
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v dockutil >/dev/null 2>&1; then
+  echo "dockutil is required. Install optional tools with './brew.sh install --optional-tools' first."
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOTFILES_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+LAYOUT_FILE="${1:-$DOTFILES_DIR/dock/layout.sh}"
+
+if [[ ! -f "$LAYOUT_FILE" ]]; then
+  echo "Dock layout not found at $LAYOUT_FILE"
+  echo "Run './bin/capture-dock' to save the current Dock into the repo first."
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$LAYOUT_FILE"
+
+echo "Resetting Dock from $LAYOUT_FILE..."
+dockutil --no-restart --remove all
+
+for app in "${DOCK_APPS[@]}"; do
+  if [[ -e "$app" ]]; then
+    dockutil --no-restart --add "$app"
+  else
+    echo "Skipping missing Dock app: $app"
+  fi
+done
+
+for item in "${DOCK_OTHERS[@]:-}"; do
+  [[ -n "$item" ]] || continue
+  IFS='|' read -r path view display sort <<<"$item"
+
+  if [[ ! -e "$path" ]]; then
+    echo "Skipping missing Dock item: $path"
+    continue
+  fi
+
+  dockutil --no-restart --add "$path" --section others --view "$view" --display "$display" --sort "$sort"
+done
+
+killall Dock >/dev/null 2>&1 || true
+echo "Dock updated."

--- a/script/setup-github-auth
+++ b/script/setup-github-auth
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+resolve_script_dir() {
+  local source_path="$1"
+
+  while [[ -L "$source_path" ]]; do
+    local source_dir
+    source_dir="$(cd -P "$(dirname "$source_path")" && pwd)"
+    source_path="$(readlink "$source_path")"
+    if [[ "$source_path" != /* ]]; then
+      source_path="$source_dir/$source_path"
+    fi
+  done
+
+  cd -P "$(dirname "$source_path")" && pwd
+}
+
+github_ssh_remote() {
+  local remote_url="$1"
+  local owner_repo
+
+  case "$remote_url" in
+  https://github.com/*)
+    owner_repo="${remote_url#https://github.com/}"
+    ;;
+  git@github.com:*)
+    owner_repo="${remote_url#git@github.com:}"
+    ;;
+  ssh://git@github.com/*)
+    owner_repo="${remote_url#ssh://git@github.com/}"
+    ;;
+  *)
+    return 1
+    ;;
+  esac
+
+  owner_repo="${owner_repo%.git}"
+  if [[ "$owner_repo" != */* ]]; then
+    return 1
+  fi
+
+  printf 'git@github.com:%s.git\n' "$owner_repo"
+}
+
+update_dotfiles_remote_to_ssh() {
+  local repo_dir="$1"
+  local remote_url ssh_remote_url
+
+  if ! git -C "$repo_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Skipping remote update because $repo_dir is not a git repository."
+    return
+  fi
+
+  if ! remote_url="$(git -C "$repo_dir" remote get-url --push origin 2>/dev/null)"; then
+    echo "Skipping remote update because the dotfiles repo has no origin remote."
+    return
+  fi
+
+  if ! ssh_remote_url="$(github_ssh_remote "$remote_url")"; then
+    echo "Skipping remote update because origin is not a supported GitHub URL: $remote_url"
+    return
+  fi
+
+  if [[ "$remote_url" == "$ssh_remote_url" ]]; then
+    echo "Dotfiles origin already uses SSH: $ssh_remote_url"
+    return
+  fi
+
+  git -C "$repo_dir" remote set-url origin "$ssh_remote_url"
+  echo "Updated dotfiles origin to SSH: $ssh_remote_url"
+}
+
+test_github_ssh() {
+  local status=0
+
+  set +e
+  ssh -o StrictHostKeyChecking=accept-new -T git@github.com
+  status=$?
+  set -e
+
+  case "$status" in
+  1)
+    echo "GitHub SSH authentication looks good."
+    ;;
+  255)
+    echo "GitHub SSH test failed."
+    exit 1
+    ;;
+  *)
+    echo "GitHub SSH test exited with status $status."
+    ;;
+  esac
+}
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh is required. Run ./setup-a-new-machine.sh first."
+  exit 1
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "git is required."
+  exit 1
+fi
+
+if ! command -v ssh >/dev/null 2>&1; then
+  echo "ssh is required."
+  exit 1
+fi
+
+SCRIPT_DIR="$(resolve_script_dir "${BASH_SOURCE[0]}")"
+DOTFILES_REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "Starting GitHub CLI authentication with SSH for github.com..."
+gh auth login --hostname github.com --git-protocol ssh --web
+gh config set git_protocol ssh --host github.com
+gh alias set --clobber open 'repo view --web'
+
+update_dotfiles_remote_to_ssh "$DOTFILES_REPO_DIR"
+test_github_ssh

--- a/script/setup-shell
+++ b/script/setup-shell
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "git is required."
+  exit 1
+fi
+
+OH_MY_ZSH_DIR="${ZSH:-$HOME/.oh-my-zsh}"
+OH_MY_ZSH_CUSTOM_DIR="${ZSH_CUSTOM:-$OH_MY_ZSH_DIR/custom}"
+PLUGIN_DIR="$OH_MY_ZSH_CUSTOM_DIR/plugins"
+
+clone_repo() {
+  local repo_url="$1"
+  local destination="$2"
+  local label="$3"
+
+  mkdir -p "$(dirname "$destination")"
+  git clone --depth 1 "$repo_url" "$destination" >/dev/null
+  echo "Installed $label at $destination."
+}
+
+update_repo() {
+  local destination="$1"
+  local label="$2"
+
+  if ! git -C "$destination" diff --quiet --ignore-submodules --exit-code; then
+    echo "Skipping $label update because $destination has local modifications."
+    return
+  fi
+
+  if ! git -C "$destination" diff --cached --quiet --ignore-submodules --exit-code; then
+    echo "Skipping $label update because $destination has staged changes."
+    return
+  fi
+
+  git -C "$destination" pull --ff-only >/dev/null
+  echo "Updated $label at $destination."
+}
+
+ensure_repo() {
+  local repo_url="$1"
+  local destination="$2"
+  local label="$3"
+
+  if [[ -d "$destination/.git" ]]; then
+    update_repo "$destination" "$label"
+    return
+  fi
+
+  if [[ -e "$destination" ]]; then
+    echo "Skipping $label because $destination exists and is not a git checkout."
+    return
+  fi
+
+  clone_repo "$repo_url" "$destination" "$label"
+}
+
+ensure_repo "https://github.com/ohmyzsh/ohmyzsh.git" "$OH_MY_ZSH_DIR" "oh-my-zsh"
+ensure_repo "https://github.com/zsh-users/zsh-autosuggestions.git" "$PLUGIN_DIR/zsh-autosuggestions" "zsh-autosuggestions"
+ensure_repo "https://github.com/joshskidmore/zsh-fzf-history-search.git" "$PLUGIN_DIR/zsh-fzf-history-search" "zsh-fzf-history-search"
+
+echo "Managed shell tooling is ready."

--- a/setup-a-new-machine.sh
+++ b/setup-a-new-machine.sh
@@ -20,7 +20,8 @@ fi
 SKIP_NVM_HINT=1 "$SCRIPT_DIR/brew.sh" "$@"
 
 if [[ "$subcommand" == "install" || "$subcommand" == "upgrade" ]]; then
-  "$SCRIPT_DIR/bin/setup-ai-coding-tools"
+  "$SCRIPT_DIR/script/setup-shell"
+  "$SCRIPT_DIR/script/setup-ai-coding-tools"
 fi
 
 cat <<'EOF'
@@ -29,15 +30,15 @@ Machine setup checklist:
 
 - Change battery to show percentage
 - Fix Finder sidebar and other Finder preferences
-- If you installed optional tools, run `./bin/setup-dock` to recreate the Dock layout saved in this repo
+- If you installed optional tools, run `./script/setup-dock` to recreate the Dock layout saved in this repo
 - Change mouse scroll direction if needed
 - Change mouse to tap to click if needed
 - Download JetBrains Mono and add it in Font Book
 
 Shell setup:
 
-- Install oh-my-zsh: sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
-- Install the zsh plugins you want, for example `zsh-autosuggestions`
+- `./setup-a-new-machine.sh` installs and updates the repo-managed shell stack: `oh-my-zsh`, `zsh-autosuggestions`, and `zsh-fzf-history-search`
+- Re-run `./script/setup-shell` any time you want to refresh that managed shell tooling without re-running the full bootstrap
 - `direnv` hooks are enabled automatically in `~/.zshrc` when `direnv` is installed
 - `zoxide` hooks are enabled automatically in `~/.zshrc` when optional tools are installed
 - This repo expects `nvm` to use `~/.nvm`
@@ -48,18 +49,18 @@ Shell setup:
 
 GitHub setup:
 
-- Run `./bin/setup-github-auth` after this script finishes to sign in with `gh`, configure the `open` alias for `repo view --web`, let GitHub CLI create or upload an SSH key if needed, test `ssh -T git@github.com`, and switch this repo's `origin` remote from HTTPS to SSH
+- Run `./script/setup-github-auth` after this script finishes to sign in with `gh`, configure the `open` alias for `repo view --web`, let GitHub CLI create or upload an SSH key if needed, test `ssh -T git@github.com`, and switch this repo's `origin` remote from HTTPS to SSH
 
 Repo-managed files:
 
 - `move-in.sh` links only these files into `$HOME`: `.aliases`, `.exports`, `.extras`, `.functions`, `.gitconfig`, and `.zshrc`
-- `move-in.sh` also symlinks every file in this repo's `bin/` directory into `~/bin`
-- Repo docs, bootstrap scripts, and `Brewfile*` are intentionally excluded from that symlink step
+- `move-in.sh` also symlinks only these user-facing helpers into `~/bin`: `add-ruby`, `capture-dock`, `pull-request.sh`, and `symlinkToDotfilesRepo.sh`
+- Repo docs, bootstrap scripts in `script/`, and `Brewfile*` are intentionally excluded from that symlink step
 
 Optional CLI extras:
 
 - Re-run this script with `--optional-tools` or `INSTALL_OPTIONAL_TOOLS=1` to install `stow`, `tmux`, `zoxide`, `btop`, `ncdu`, and `dockutil`
-- `dockutil` powers `./bin/capture-dock` and `./bin/setup-dock` for saving and restoring the repo's Dock layout
+- `dockutil` powers `./bin/capture-dock` and `./script/setup-dock` for saving and restoring the repo's Dock layout
 
 Postgres:
 


### PR DESCRIPTION
## Summary
- move repo-only setup helpers into `script/` and leave compatibility shims in `bin/`
- update `move-in.sh` so only intentionally user-facing helpers are symlinked into `~/bin`
- refresh `README.md` and `setup-a-new-machine.sh` so the `bin/` vs `script/` split is explicit

## Why
This keeps `~/bin` focused on day-to-day commands while preserving a migration path for existing machines that already have the old `bin/setup-*` symlinks.

Closes #25.

## Validation
- `bash -n setup-a-new-machine.sh bin/setup-shell script/setup-shell script/setup-ai-coding-tools script/setup-github-auth script/setup-dock bin/setup-ai-coding-tools bin/setup-dock bin/setup-github-auth move-in.sh bin/capture-dock bin/add-ruby bin/pull-request.sh bin/symlinkToDotfilesRepo.sh`
- rebased the issue work onto a fresh branch from `main` and resolved cherry-pick conflicts against current docs/setup flow