### PR TITLE
[codex] Remove npm-check dependency from update aliases

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -80,7 +80,7 @@ alias emptytrash=" \
 "
 
 # Update installed Ruby gems, Homebrew, npm, and their installed packages
-alias brew_update="brew -v update; brew upgrade --force-bottle --cleanup; brew cleanup; brew cask cleanup; brew prune; brew doctor; npm-check -g -u"
+alias brew_update="brew -v update; brew upgrade --force-bottle --cleanup; brew cleanup; brew cask cleanup; brew prune; brew doctor"
 alias update_brew_npm_gem='brew_update; npm install npm -g; npm update -g; sudo gem update --system; sudo gem update --no-document'
 alias dotfiles="cd ~/workspace/dotfiles"
 alias b="bundle"

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ This repo expects `nvm` to use `~/.nvm`.
 
 - `@openai/codex`
 
+The repo-defined update aliases do not require `npm-check`. After Node is installed, `update_brew_npm_gem` uses the built-in `npm update -g` flow for global npm packages.
+
 Claude Code is installed through the `claude-code` Homebrew cask in `Brewfile`.
 
 Useful verification commands:

--- a/setup-a-new-machine.sh
+++ b/setup-a-new-machine.sh
@@ -44,6 +44,7 @@ Shell setup:
 - This repo expects `nvm` to use `~/.nvm`
 - `./setup-a-new-machine.sh` installs the current Node LTS release through `nvm`
 - Verify Node is available with `node --version` and `npm --version`
+- Repo-defined update aliases do not require `npm-check`; `update_brew_npm_gem` uses built-in `npm update -g` after Node is installed
 - Verify the AI coding CLIs with `codex --version` and `claude --version`
 - Run `codex login` and start `claude` once to finish authentication
 


### PR DESCRIPTION
## Summary
- remove the `npm-check -g -u` call from `brew_update`
- keep npm global package updates on the built-in `npm update -g` path in `update_brew_npm_gem`
- document that the repo-defined update aliases do not require `npm-check`

## Why
The update workflow assumed `npm-check` was installed, but the bootstrap does not install it on a fresh machine. That left a latent missing-command failure in the repo-defined aliases.

## Impact
Fresh machine setup no longer depends on an unmanaged global npm package for the standard update workflow, and the README/bootstrap guidance now matches the actual behavior.

## Validation
- `zsh -n .aliases`
- `zsh -fc 'source ./.aliases && alias brew_update && alias update_brew_npm_gem'`
- `bash -n setup-a-new-machine.sh`
- `shellcheck setup-a-new-machine.sh`
- `git diff --check --cached -- .aliases README.md setup-a-new-machine.sh`

Closes #19