### PR TITLE
[codex] Add manual cask smoke workflow

### DIFF
--- a/.github/workflows/cask-smoke.yml
+++ b/.github/workflows/cask-smoke.yml
@@ -34,6 +34,7 @@ jobs:
         shell: bash
 
     env:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
       HOMEBREW_NO_INSTALL_CLEANUP: "1"
 
     steps:

--- a/.github/workflows/cask-smoke.yml
+++ b/.github/workflows/cask-smoke.yml
@@ -1,0 +1,65 @@
+name: Cask Smoke Test
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cask-smoke-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Smoke ${{ matrix.cask }}
+    runs-on: macos-latest
+    timeout-minutes: 45
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cask: google-chrome
+            app_name: Google Chrome.app
+          - cask: iterm2
+            app_name: iTerm.app
+          - cask: sublime-text
+            app_name: Sublime Text.app
+          - cask: visual-studio-code
+            app_name: Visual Studio Code.app
+
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      HOMEBREW_NO_INSTALL_CLEANUP: "1"
+
+    steps:
+      - name: Prepare isolated app directory
+        env:
+          APPDIR: ${{ runner.temp }}/Applications
+        run: mkdir -p "$APPDIR"
+
+      - name: Install and verify cask
+        env:
+          APPDIR: ${{ runner.temp }}/Applications
+          CASK: ${{ matrix.cask }}
+          APP_NAME: ${{ matrix.app_name }}
+        run: |
+          set -euo pipefail
+
+          app_path="$APPDIR/$APP_NAME"
+
+          cleanup() {
+            if brew list --cask "$CASK" >/dev/null 2>&1; then
+              brew uninstall --cask "$CASK"
+            fi
+          }
+          trap cleanup EXIT
+
+          brew install --cask --appdir="$APPDIR" "$CASK"
+
+          [[ -d "$app_path" ]]
+          codesign --verify --deep "$app_path"


### PR DESCRIPTION
## Summary
- add a `workflow_dispatch`-only cask smoke workflow
- smoke-test `google-chrome`, `iterm2`, `sublime-text`, and `visual-studio-code` in a matrix
- install each cask into `$RUNNER_TEMP/Applications`, assert the expected `.app` exists, run `codesign --verify --deep`, and uninstall it

## Why
- keeps PR smoke tests formula-only while preserving a narrow manual check for safe GUI casks
- addresses the scope described in #15 without widening the existing bootstrap smoke workflow

## Assumptions
- `codesign --verify --deep` is part of the manual smoke for the initial allowlist
- the workflow remains hard-coded to the initial four safe casks from #15

## Validation
- parsed `.github/workflows/cask-smoke.yml` locally as YAML
- verified the workflow is `workflow_dispatch`-only and contains the expected 4-entry matrix

Closes #15