### PR TITLE
[codex] Run Bootstrap Smoke Test on every pull request

### DIFF
--- a/.github/workflows/bootstrap-smoke.yml
+++ b/.github/workflows/bootstrap-smoke.yml
@@ -9,21 +9,6 @@ on:
         default: false
         required: false
   pull_request:
-    paths:
-      - ".github/workflows/bootstrap-smoke.yml"
-      - ".aliases"
-      - ".exports"
-      - ".extras"
-      - ".functions"
-      - ".gitconfig"
-      - ".zshrc"
-      - "Brewfile"
-      - "Brewfile.optional"
-      - "brew.sh"
-      - "move-in.sh"
-      - "setup-a-new-machine.sh"
-      - "bin/**"
-      - "dock/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- run the Bootstrap Smoke Test workflow on every pull request
- remove pull request path filtering that prevented workflow-only PRs from triggering the smoke test

## Why
The workflow currently skips some PRs because `pull_request.paths` excludes workflow-only changes. That makes PR checks look missing even when the workflow definition changed.

## Impact
Bootstrap Smoke Test now runs on all pull requests while preserving existing manual `workflow_dispatch` behavior.

## Root cause
The PR trigger was constrained by path filters, so GitHub did not schedule the workflow for some valid pull requests.

## Validation
- reused existing local commit `fd88c99849f89dcd3559b6efc6e3c3676586ee5d` without re-editing
- pushed `codex/issue-39-bootstrap-smoke-pr-trigger` to `origin`
- PR creation itself should trigger the pull request workflow on GitHub

Fixes #39