### PR TITLE
[codex] Fix Google Chrome false failure in Cask Smoke Test

### DIFF
--- a/.github/workflows/cask-smoke.yml
+++ b/.github/workflows/cask-smoke.yml
@@ -52,9 +52,15 @@ jobs:
           set -euo pipefail
 
           app_path="$APPDIR/$APP_NAME"
+          was_installed_before=0
+          cleanup_cask=0
+
+          if brew list --cask "$CASK" >/dev/null 2>&1; then
+            was_installed_before=1
+          fi
 
           cleanup() {
-            if brew list --cask "$CASK" >/dev/null 2>&1; then
+            if [[ "$cleanup_cask" -eq 1 ]]; then
               brew uninstall --cask "$CASK"
             fi
           }
@@ -62,5 +68,14 @@ jobs:
 
           brew install --cask --appdir="$APPDIR" "$CASK"
 
-          [[ -d "$app_path" ]]
+          if [[ -d "$app_path" ]]; then
+            cleanup_cask=1
+          elif [[ "$was_installed_before" -eq 1 ]]; then
+            echo "::notice title=Skipped isolated verification::$CASK was already installed before this job, so Homebrew did not install it into $APPDIR"
+            exit 0
+          else
+            echo "::error title=Isolated app not found::Expected $app_path after installing $CASK"
+            exit 1
+          fi
+
           codesign --verify --deep "$app_path"

--- a/.github/workflows/cask-smoke.yml
+++ b/.github/workflows/cask-smoke.yml
@@ -52,6 +52,7 @@ jobs:
           set -euo pipefail
 
           app_path="$APPDIR/$APP_NAME"
+          verify_app_path="$app_path"
           was_installed_before=0
           cleanup_cask=0
 
@@ -71,11 +72,14 @@ jobs:
           if [[ -d "$app_path" ]]; then
             cleanup_cask=1
           elif [[ "$was_installed_before" -eq 1 ]]; then
-            echo "::notice title=Skipped isolated verification::$CASK was already installed before this job, so Homebrew did not install it into $APPDIR"
-            exit 0
+            verify_app_path="/Applications/$APP_NAME"
+            if [[ ! -d "$verify_app_path" ]]; then
+              echo "::error title=Preinstalled app not found::Expected $verify_app_path for preinstalled $CASK when isolated install was skipped"
+              exit 1
+            fi
           else
             echo "::error title=Isolated app not found::Expected $app_path after installing $CASK"
             exit 1
           fi
 
-          codesign --verify --deep "$app_path"
+          codesign --verify --deep "$verify_app_path"


### PR DESCRIPTION
## Summary
- track whether the cask was already installed before the job starts
- only uninstall during cleanup when the workflow actually installed the app into the isolated app directory
- skip isolated-path verification when Homebrew reports the cask is already installed globally

## Root Cause
GitHub-hosted runners can already have `google-chrome` installed outside the isolated app directory. In that case `brew install --cask --appdir="$APPDIR"` warns that the latest version is already installed, no app appears under `$APPDIR`, and the old cleanup trap can remove the preexisting global app.

## Validation
- `env -u GEM_HOME -u GEM_PATH /usr/bin/ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cask-smoke.yml"); puts "YAML parse OK"'`

Closes #42
