### PR TITLE
Clarify Rectangle bootstrap choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Managed App Store installs currently include:
 - `Pages`
 - `Xcode`
 
-`Spectacle` is intentionally not in the `Brewfile` because the legacy cask is no longer available in Homebrew. Use `Rectangle` instead for window management.
+`Spectacle` is intentionally not in the `Brewfile` because the legacy cask is no longer available in Homebrew. If you want window management, install `Rectangle` manually (for example: `brew install --cask rectangle`, or install it from the App Store).
 
 ## Manual Follow-Up
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Managed App Store installs currently include:
 - `Pages`
 - `Xcode`
 
-`Spectacle` is intentionally not in the `Brewfile` because the legacy cask is no longer available in Homebrew.
+`Spectacle` is intentionally not in the `Brewfile` because the legacy cask is no longer available in Homebrew. Use `Rectangle` instead for window management.
 
 ## Manual Follow-Up
 


### PR DESCRIPTION
Issue #20.\n\nSummary:\n- Keep Spectacle omitted from the Brewfile.\n- Clarify in README that Rectangle is the replacement for window management.\n\nValidation:\n- Reviewed Brewfile and README references to Spectacle/Rectangle.\n- Confirmed no Brewfile change was needed.\n\nFiles changed:\n- README.md